### PR TITLE
Fix BankClient loop

### DIFF
--- a/BankClient/Program.cs
+++ b/BankClient/Program.cs
@@ -72,5 +72,4 @@ while (!lifetime.ApplicationStopping.IsCancellationRequested)
 
     // Sleep and run again
     await Task.Delay(TimeSpan.FromMilliseconds(200));
-    break;
 }

--- a/BankServer/Program.cs
+++ b/BankServer/Program.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection; // Add this to fix CS1061
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Orleans.Transactions.Abstractions; // Add this to fix CS0246
+using Orleans.Transactions.Abstractions;
 
 await Host.CreateDefaultBuilder(args)
     .ConfigureLogging(logging =>


### PR DESCRIPTION
## Summary
- remove a stray `break` so the client continues processing transactions without exiting after the first iteration
- remove leftover comments from the server program

## Testing
- `dotnet build BankAccount.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684565a350008325acd72f509e966686