### PR TITLE
Enable Azure Table Storage for Orleans

### DIFF
--- a/.github/workflows/azure-resources.yml
+++ b/.github/workflows/azure-resources.yml
@@ -1,0 +1,51 @@
+name: Provision Azure Tables
+
+on:
+  workflow_dispatch:
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Create resource group
+        run: az group create --name "$RESOURCE_GROUP" --location "$LOCATION"
+        env:
+          RESOURCE_GROUP: ${{ secrets.AZURE_RG }}
+          LOCATION: ${{ secrets.AZURE_LOCATION }}
+
+      - name: Create storage account
+        run: |
+          az storage account create \
+            --name "$STORAGE_ACCOUNT" \
+            --resource-group "$RESOURCE_GROUP" \
+            --location "$LOCATION" \
+            --sku Standard_LRS \
+            --kind StorageV2
+        env:
+          STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+          RESOURCE_GROUP: ${{ secrets.AZURE_RG }}
+          LOCATION: ${{ secrets.AZURE_LOCATION }}
+
+      - name: Get connection string
+        id: conn
+        run: |
+          az storage account show-connection-string \
+            --name "$STORAGE_ACCOUNT" \
+            --resource-group "$RESOURCE_GROUP" \
+            --query connectionString -o tsv >> conn.txt
+          echo "connection=$(cat conn.txt)" >> "$GITHUB_OUTPUT"
+        env:
+          STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+          RESOURCE_GROUP: ${{ secrets.AZURE_RG }}
+
+      - name: Create tables
+        run: |
+          az storage table create --name OrleansGrainState --connection-string "${{ steps.conn.outputs.connection }}"
+          az storage table create --name TransactionalState --connection-string "${{ steps.conn.outputs.connection }}"
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: ${{ steps.conn.outputs.connection }}

--- a/BankServer/BankServer.csproj
+++ b/BankServer/BankServer.csproj
@@ -7,6 +7,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
     <PackageReference Include="Microsoft.Orleans.Server"/>
     <PackageReference Include="Microsoft.Orleans.Transactions"/>
+    <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage"/>
+    <PackageReference Include="Microsoft.Orleans.Transactions.AzureStorage"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AccountTransfer.Grains\AccountTransfer.Grains.csproj"/>

--- a/BankServer/Program.cs
+++ b/BankServer/Program.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Orleans.Transactions.Abstractions;
@@ -14,7 +15,16 @@ await Host.CreateDefaultBuilder(args)
     {
         siloBuilder
             .UseLocalhostClustering()
-            .AddMemoryGrainStorageAsDefault()
+            .AddAzureTableGrainStorageAsDefault(options =>
+            {
+                var connectionString = Environment.GetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING");
+                options.ConfigureTableServiceClient(connectionString);
+            })
+            .AddAzureTableTransactionalStateStorageAsDefault(options =>
+            {
+                var connectionString = Environment.GetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING");
+                options.ConfigureTableServiceClient(connectionString);
+            })
             .UseTransactions();
     })
     .RunConsoleAsync();

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,5 +11,7 @@
     <PackageVersion Include="Microsoft.Orleans.Sdk" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Orleans.Server" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Orleans.Transactions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Orleans.Transactions.AzureStorage" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -130,3 +130,15 @@ When a withdraw would overdraw an account, the client will print an error like s
 Error transferring 100 credits from Derick to Xaawo: Transaction 2edc92f5-a94d-4167-9522-fa661cc030ff Aborted because of an unhandled exception in a grain method call. See InnerException for details.
         InnerException: Withdrawing 100 credits from account "Derick" would overdraw it. This account has 0 credits.
 ```
+
+## Configuring Azure Table Storage
+
+Set the `AZURE_STORAGE_CONNECTION_STRING` environment variable before starting the `BankServer` process to enable Azure Table Storage for grain and transactional state. Tables named `OrleansGrainState` and `TransactionalState` will be created if they do not exist.
+
+This repository includes a workflow, `.github/workflows/azure-resources.yml`, which provisions these tables. Configure the following secrets and run the workflow:
+
+- `AZURE_CREDENTIALS` – credentials JSON for `azure/login`.
+- `AZURE_RG` – resource group name.
+- `AZURE_LOCATION` – Azure region.
+- `AZURE_STORAGE_ACCOUNT` – storage account name.
+


### PR DESCRIPTION
## Summary
- use Azure Table Storage for grain and transaction state
- add provisioning workflow for Azure resources
- document how to configure Azure Table Storage

## Testing
- `dotnet restore BankAccount.sln`
- `dotnet build BankAccount.sln --no-restore`
- `az --version | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_6845687fccf88325944d8f62f4d89405